### PR TITLE
build by default; add dependencies to targets; add build-dep step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build: deps
 	go build -v
 
 deps:
-	go get -insecure gopkg.in/yaml.v2
+	go get -insecure gopkg.in/yaml.v2 github.com/aws/aws-sdk-go/aws/session github.com/aws/aws-sdk-go/service/sts github.com/spf13/cobra github.com/hashicorp/go-getter
 
 test: deps
 	go test -race -cover $(PACKAGES)

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,13 @@ dist: deps
 	gox -osarch="darwin/amd64" -osarch="linux/386" -osarch="linux/amd64" -osarch="windows/amd64" \
 		-ldflags "-X main.version=${BUILD_VERSION}" -output "dist/ncd_{{.OS}}_{{.Arch}}"
 
-prerelease: dist
+ghr:
+	go get -u github.com/tcnksm/ghr
+
+prerelease: ghr dist
 	ghr --prerelease -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} --replace `git describe --tags` dist/
 
-release: dist
+release: ghr dist
 	ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} --replace `git describe --tags` dist/
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,6 @@ clean:
 	rm fargate-create
 	rm -rf iac
 	rm -rf fargate-create-template
+
+install: build
+	cp -p fargate-create /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 PACKAGES := $(shell go list ./... | grep -v /mock)
 BUILD_VERSION := $(shell git describe --tags)
 
-build: deps
-	make clean
+build: deps clean
 	go build -v
 
 deps:
@@ -28,7 +27,7 @@ release: ghr dist
 	ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} --replace `git describe --tags` dist/
 
 clean:
-	rm fargate-create
+	rm -f fargate-create
 	rm -rf iac
 	rm -rf fargate-create-template
 

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,27 @@
-.PHONY: mocks test build dist clean
+.PHONY: deps mocks test build dist clean
 
 PACKAGES := $(shell go list ./... | grep -v /mock)
 BUILD_VERSION := $(shell git describe --tags)
 
-test:
-	go test -race -cover $(PACKAGES)
-
-build:
+build: deps
 	make clean
 	go build -v
 
-dist:
+deps:
+	go get -insecure gopkg.in/yaml.v2
+
+test: deps
+	go test -race -cover $(PACKAGES)
+
+dist: deps
 	echo building ${BUILD_VERSION}
 	gox -osarch="darwin/amd64" -osarch="linux/386" -osarch="linux/amd64" -osarch="windows/amd64" \
 		-ldflags "-X main.version=${BUILD_VERSION}" -output "dist/ncd_{{.OS}}_{{.Arch}}"
 
-prerelease:
+prerelease: build
 	ghr --prerelease -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} --replace `git describe --tags` dist/
 
-release:
+release: build
 	ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} --replace `git describe --tags` dist/
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ dist: deps
 	gox -osarch="darwin/amd64" -osarch="linux/386" -osarch="linux/amd64" -osarch="windows/amd64" \
 		-ldflags "-X main.version=${BUILD_VERSION}" -output "dist/ncd_{{.OS}}_{{.Arch}}"
 
-prerelease: build
+prerelease: dist
 	ghr --prerelease -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} --replace `git describe --tags` dist/
 
-release: build
+release: dist
 	ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} --replace `git describe --tags` dist/
 
 clean:


### PR DESCRIPTION
The Makefile targets now include dependencies, and "make" defaults to "build" (instead of "test"). There's now a "make deps" that does a "go get" on the external dependencies, and the build, test, and dist targets depend on it. 