### PR TITLE
adds support for scheduled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The following stacks are popular configurations that can be used with `fargate-c
 - [Web Application (ALB - HTTP/HTTPS)](https://github.com/turnerlabs/terraform-ecs-fargate#fargate-create)
 - [Network Application (NLB)](https://github.com/turnerlabs/terraform-ecs-fargate-nlb#fargate-create)
 - [Background Worker](https://github.com/turnerlabs/terraform-ecs-fargate-background-worker#fargate-create)
+- [Scheduled Task](https://github.com/turnerlabs/terraform-ecs-fargate-scheduled-task#fargate-create)
  
 
 ### Help

--- a/examples/fargate-create.yml
+++ b/examples/fargate-create.yml
@@ -1,6 +1,10 @@
 # this file is used by fargate-create (https://github.com/turnerlabs/fargate-create)
 # if not using fargate-create, this file can be ignored/deleted
 
+# the type of template (e.g.: Service, ScheduledTask)
+templateType: Service
+
+# file customization
 prompts:
 
   - question: "Would you like HTTPS support (requires a certificate)?"


### PR DESCRIPTION
fargate-create.yml
```yaml
templateType: ScheduledTask
```

- adds `task` and `rule` to generated `fargate.yml`

- changes generated `deploy.sh` to support scheduled tasks
```shell
# deploy image and env vars
REVISION=$(fargate task register -f docker-compose.yml)
fargate events target -r ${REVISION}
```