### PR TITLE
adds upgrade command (closes #20)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,6 +103,10 @@ func (context scaffoldContext) GetAccount() string {
 //gets run before every command
 func persistentPreRun(cmd *cobra.Command, args []string) {
 
+	if !(cmd.Name() == "fargate-create" || cmd.Name() == "build") {
+		return
+	}
+
 	//validate that input varFile exists
 	if _, err := os.Stat(varFile); os.IsNotExist(err) {
 		fmt.Printf("Can't find %s. Use the --file flag to specify a .tfvars or .json file \n", varFile)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,11 +13,12 @@ import (
 )
 
 const (
-	tempDir            = "fargate-create-template"
-	templateConfigFile = "fargate-create.yml"
-	varFormatHCL       = ".tfvars"
-	varFormatJSON      = ".json"
-	defaultTemplate    = "git@github.com:turnerlabs/terraform-ecs-fargate"
+	tempDir                 = "fargate-create-template"
+	templateConfigFile      = "fargate-create.yml"
+	targetInfrastructureDir = "iac"
+	varFormatHCL            = ".tfvars"
+	varFormatJSON           = ".json"
+	defaultTemplate         = "git@github.com:turnerlabs/terraform-ecs-fargate"
 )
 
 var verbose bool
@@ -28,9 +29,9 @@ var yesUseDefaults bool
 var context scaffoldContext
 
 var rootCmd = &cobra.Command{
-	Use:   "fargate-create",
-	Short: "Scaffold out new AWS ECS/Fargate applications based on Terraform templates and Fargate CLI",
-	Run:   run,
+	Use:              "fargate-create",
+	Short:            "Scaffold out new AWS ECS/Fargate applications based on Terraform templates and Fargate CLI",
+	Run:              run,
 	PersistentPreRun: persistentPreRun,
 	Example: `
 # Scaffold an environment using the latest default template
@@ -44,6 +45,9 @@ fargate-create -t git@github.com:turnerlabs/terraform-ecs-fargate?ref=v0.4.3
 
 # Scaffold out files for various build systems
 fargate-create build circleciv2
+
+# keep your template up to date
+fargate-create upgrade
 
 # Use a template stored in s3
 AWS_ACCESS_KEY=xyz AWS_SECRET_KEY=xyz AWS_REGION=us-east-1 \
@@ -69,7 +73,7 @@ func Execute(version string) {
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 	rootCmd.PersistentFlags().StringVarP(&varFile, "file", "f", "terraform.tfvars", "file specifying Terraform input variables, in either HCL or JSON format")
-	rootCmd.PersistentFlags().StringVarP(&targetDir, "target-dir", "d", "iac", "target directory where code is outputted")
+	rootCmd.PersistentFlags().StringVarP(&targetDir, "target-dir", "d", targetInfrastructureDir, "target directory where code is outputted")
 	rootCmd.PersistentFlags().StringVarP(&templateURL, "template", "t", defaultTemplate, "URL of a compatible Terraform template")
 	rootCmd.PersistentFlags().BoolVarP(&yesUseDefaults, "yes", "y", false, "don't ask questions and use defaults")
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var upgradeYes bool
+
+var upgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Keep a terraform template up to date",
+	Run:   doUpgrade,
+	Example: `
+fargate-create upgrade
+fargate-create upgrade -t git@github.com:turnerlabs/terraform-ecs-fargate-scheduled-task
+fargate-create upgrade -d infrastructure
+`,
+}
+
+func init() {
+	rootCmd.AddCommand(upgradeCmd)
+}
+
+func doUpgrade(cmd *cobra.Command, args []string) {
+
+	//has the user done a previous install?
+	notFound := false
+	if _, err := os.Stat(targetDir); err != nil {
+		notFound = true
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, baseDir)); err != nil {
+		notFound = true
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, envDir)); err != nil {
+		notFound = true
+	}
+	if notFound {
+		check(errors.New("no existing template found"))
+	}
+
+	//fetch the template from the source
+	templateDir := downloadTerraformTemplate()
+	debug("downloaded to:", templateDir)
+
+	//process /base first, then iterate over /env
+	srcDir := filepath.Join(templateDir, baseDir)
+	destDir := filepath.Join(targetDir, baseDir)
+	adds, updates := upgradeDirectory(srcDir, destDir)
+
+	//process each installed environment
+	srcDir = filepath.Join(templateDir, envDir, devDir)
+	objects, err := ioutil.ReadDir(filepath.Join(targetDir, envDir))
+	check(err)
+	for _, o := range objects {
+		if o.IsDir() {
+			destDir = filepath.Join(targetDir, envDir, o.Name())
+
+			//apply env transformation in src before upgrading
+			transformMainTFToContext(srcDir, context.Profile, context.App, context.Env)
+
+			//upgrade env directory
+			a, u := upgradeDirectory(srcDir, destDir)
+			adds += a
+			updates += u
+		}
+	}
+
+	//delete download dir
+	os.RemoveAll(templateDir)
+
+	fmt.Println()
+	fmt.Println("---------------------------------------")
+	fmt.Println("upgrade complete")
+	if adds > 0 || updates > 0 {
+		fmt.Println()
+		fmt.Println(`run the following commands to apply these changes:
+terraform init -upgrade=true
+terraform apply`)
+	}
+}
+
+func upgradeDirectory(srcDir string, destDir string) (int, int) {
+
+	//prompt for updates to existing local files
+	//add new required files
+	//prompt to add new optional files (using fargate-create.yml)
+
+	fmt.Println()
+	fmt.Println("---------------------------------------")
+	fmt.Println("upgrading", destDir)
+	fmt.Println("---------------------------------------")
+
+	updates := 0
+	adds := 0
+
+	//iterate src files
+	files, err := ioutil.ReadDir(srcDir)
+	check(err)
+	for _, f := range files {
+		file := f.Name()
+
+		//only process .tf or .md files
+		if !(strings.HasSuffix(file, ".tf") || strings.HasSuffix(file, ".md")) {
+			continue
+		}
+
+		//does matching file in template exist?
+		source := filepath.Join(srcDir, file)
+		dest := filepath.Join(destDir, file)
+		debug(fmt.Sprintf("source: %s | dest: %s", source, dest))
+
+		//can we access the source file?
+		if _, err := os.Stat(source); err == nil {
+
+			//does corresponding dest file exist?
+			if _, err = os.Stat(dest); os.IsNotExist(err) {
+				debug("new source file")
+
+				//is this file required or optional?
+				//load template config file
+				templateConfig := loadTemplateConfig(srcDir)
+				if templateConfig != nil {
+					prompt := getFilePrompt(templateConfig, file)
+					if prompt != nil {
+						//prompt to install new optional file
+						fmt.Println()
+						q := fmt.Sprintf("%s (%s) ", prompt.Question, prompt.Default)
+						response := promptAndGetResponse(q, prompt.Default)
+						if containsString(okayResponses, response) {
+							err = copyFile(source, dest)
+							check(err)
+							adds++
+						}
+					} else {
+						//write new required file
+						fmt.Println("writing", dest)
+						copyFile(source, dest)
+						adds++
+					}
+				} else {
+					debug("no template config file found")
+				}
+			} else {
+				//does dest file need updating?
+				debug("diffing")
+				if !deepCompare(source, dest) {
+					fmt.Println()
+					response := promptAndGetResponse(dest+" is out of date. Replace? (yes) ", "yes")
+					if containsString(okayResponses, response) {
+						err = copyFile(source, dest)
+						check(err)
+						updates++
+					}
+				} else {
+					debug("files match")
+				}
+			}
+		}
+	}
+	return adds, updates
+}
+
+func getFilePrompt(config *templateConfig, file string) *prompt {
+	for _, p := range config.Prompts {
+		for _, f := range p.FilesToDeleteIfNo {
+			if f == file {
+				return p
+			}
+		}
+	}
+	return nil
+}
+
+func deepCompare(file1, file2 string) bool {
+	chunkSize := 4000
+
+	f1, err := os.Open(file1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	f2, err := os.Open(file2)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		b1 := make([]byte, chunkSize)
+		_, err1 := f1.Read(b1)
+
+		b2 := make([]byte, chunkSize)
+		_, err2 := f2.Read(b2)
+
+		if err1 != nil || err2 != nil {
+			if err1 == io.EOF && err2 == io.EOF {
+				return true
+			} else if err1 == io.EOF || err2 == io.EOF {
+				return false
+			} else {
+				log.Fatal(err1, err2)
+			}
+		}
+
+		if !bytes.Equal(b1, b2) {
+			return false
+		}
+	}
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -18,6 +18,10 @@ var nokayResponses = []string{"n", "N", "no", "No", "NO"}
 
 func check(e error) {
 	if e != nil {
+
+		//clean up before exiting
+		os.RemoveAll(tempDir)
+
 		log.Fatal("ERROR: ", e)
 	}
 }


### PR DESCRIPTION
example
```
$ fargate-create upgrade
downloading terraform template git@github.com:turnerlabs/terraform-ecs-fargate

---------------------------------------
upgrading iac/base
---------------------------------------

iac/base/state.tf is out of date. Replace? (yes)

---------------------------------------
upgrading iac/env/dev
---------------------------------------

Would you like performance-based auto-scaling? (no)

Would you like an IAM user that can be used for CI/CD pipelines? (no)

iac/env/dev/ecs.tf is out of date. Replace? (yes)

Would you like to ship your container logs to logz.io (requires a key)? (no)

iac/env/dev/main.tf is out of date. Replace? (yes)

Would you like an integrated Secrets Manager secret? (no)

---------------------------------------
upgrade complete: 0 add(s), 3 update(s)

updated files:

	iac/base/state.tf
	iac/env/dev/ecs.tf
	iac/env/dev/main.tf

added files:


run the following commands to apply these changes:
terraform init -upgrade=true
terraform apply
```