### PR TITLE
defaults docker-compose.yml to v3.7 (closes #25)

### DIFF
--- a/cmd/scaffolder.go
+++ b/cmd/scaffolder.go
@@ -298,24 +298,32 @@ func getDockerComposeYml(context *scaffoldContext) string {
 	//only add docker ports if container_port context variable is specified
 	var t string
 	if context.ContainerPort != "" {
-		t = `version: "2"
+		t = `version: "3.7"
 services:
-	{{.App}}:
-		build: ../../../
-		image: {{.AccountID}}.dkr.ecr.{{.Region}}.amazonaws.com/{{.App}}:0.1.0
-		ports:    
-		- 80:{{.ContainerPort}}
-		env_file:
-		- hidden.env	
+  {{.App}}:
+    build: ../../../
+    image: {{.AccountID}}.dkr.ecr.{{.Region}}.amazonaws.com/{{.App}}:0.1.0
+    ports:
+    - {{.ContainerPort}}:{{.ContainerPort}}
+    env_file:
+    - hidden.env
+    labels:
+      aws.ecs.fargate.deploy: 1
+    #x-fargate-secrets:
+      #KEY: value
 `
 	} else {
-		t = `version: "2"
+		t = `version: "3.7"
 services:
-	{{.App}}:
-		build: ../../../
-		image: {{.AccountID}}.dkr.ecr.{{.Region}}.amazonaws.com/{{.App}}:0.1.0
-		env_file:
-		- hidden.env	
+  {{.App}}:
+    build: ../../../
+    image: {{.AccountID}}.dkr.ecr.{{.Region}}.amazonaws.com/{{.App}}:0.1.0
+    env_file:
+    - hidden.env
+    labels:
+      aws.ecs.fargate.deploy: 1
+    #x-fargate-secrets:
+      #KEY: value
 `
 	}
 	return applyTemplate(t, context)

--- a/cmd/scaffolder_test.go
+++ b/cmd/scaffolder_test.go
@@ -134,7 +134,7 @@ func TestDockerComposeYml_Port(t *testing.T) {
 	yml := getDockerComposeYml(&context)
 	t.Log(yml)
 
-	expected := "- 80:3000"
+	expected := "- 3000:3000"
 	if !strings.Contains(yml, expected) {
 		t.Errorf("expected: %s; actual: %s", expected, yml)
 	}
@@ -155,7 +155,7 @@ func TestDockerComposeYml_NoPort(t *testing.T) {
 	yml := getDockerComposeYml(&context)
 	t.Log(yml)
 
-	notexpected := "- 80:"
+	notexpected := "ports:"
 	if strings.Contains(yml, notexpected) {
 		t.Errorf("not expected: %s; actual: %s", notexpected, yml)
 	}	


### PR DESCRIPTION
- adds commented out `x-fargate-secrets` to opt-in to secrets
- adds deploy label
- makes published port = target port