### PR TITLE
adds awscodebuild build provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ $ fargate-create build <provider>
 
 The following providers are supported:
 
-- circleciv2
-- githubactions
+- [circleciv2](https://circleci.com/)
+- [githubactions](https://github.com/features/actions)
+- [awscodebuild](https://aws.amazon.com/codebuild/)
 
 
 ### Extensibility

--- a/cmd/build/awscodebuild.go
+++ b/cmd/build/awscodebuild.go
@@ -1,0 +1,47 @@
+package build
+
+//AWSCodeBuild represents a Github Actions build provider
+type AWSCodeBuild struct{}
+
+//ProvideArtifacts is the Provider implementation
+func (provider AWSCodeBuild) ProvideArtifacts(context Context) ([]*Artifact, error) {
+	artifacts := []*Artifact{}
+	artifacts = append(artifacts, createArtifact("buildspec.yml", getAWSBuildspecYAML(context)))
+	return artifacts, nil
+}
+
+func getAWSBuildspecYAML(context Context) string {
+	contextTemplate := getContextTemplate(context)
+
+	textTemplate := `version: 0.2
+  phases:
+    install:
+      runtime-versions:
+        docker: 18
+      commands:
+        - nohup /usr/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2&
+    pre_build:
+      commands:
+        - export FARGATE_CLUSTER={{ .App }}-{{ .Env }}
+        - export FARGATE_SERVICE={{ .App }}-{{ .Env }}
+        - export REPO={{ .Account }}.dkr.ecr.{{ .Region }}.amazonaws.com/{{ .App }}
+  
+        # build image:tag      
+        - export VERSION=0.1.0
+        # - export VERSION=$(jq -r .version < package.json)
+        - export BUILD=$(echo ${CODEBUILD_BUILD_ID} | cut -d ":" -f 2)
+        - export BRANCH=$(echo ${CODEBUILD_WEBHOOK_HEAD_REF} | cut -d "/" -f 3)
+        - export IMAGE=${REPO}:${VERSION}-${BRANCH}.${BUILD}
+  
+        # login to ECR registry
+        - login=$(aws ecr get-login --no-include-email) && eval "$login"
+    build:
+      commands:
+        - docker build -t ${IMAGE} .
+        - docker push ${IMAGE}
+    post_build:
+      commands:
+        - fargate service deploy -i ${IMAGE}`
+
+	return applyTemplate(textTemplate, contextTemplate)
+}

--- a/cmd/build/awscodebuild_test.go
+++ b/cmd/build/awscodebuild_test.go
@@ -1,0 +1,45 @@
+package build
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestProvider_AWSCodeBuild(t *testing.T) {
+
+	ctx := mockContext{
+		App:     "my-app",
+		Env:     "dev",
+		Account: "123456789",
+		Region:  "us-west-1",
+	}
+
+	provider, err := GetProvider("awscodebuild")
+	if err != nil {
+		t.Fail()
+	}
+	artifacts, err := provider.ProvideArtifacts(ctx)
+	if err != nil {
+		t.Fail()
+	}
+	if artifacts == nil {
+		t.Fail()
+	}
+
+	yaml := artifacts[0].FileContents
+	t.Log(yaml)
+	if artifacts[0].FilePath != "buildspec.yml" {
+		t.Fail()
+	}
+
+	repo := fmt.Sprintf(`REPO=%v.dkr.ecr.%s.amazonaws.com/%v`, ctx.Account, ctx.Region, ctx.App)
+	t.Log(repo)
+	if !strings.Contains(yaml, repo) {
+		t.Error("expecting", repo)
+	}
+	cluster := fmt.Sprintf("FARGATE_CLUSTER=%s-%s", ctx.App, ctx.Env)
+	if !strings.Contains(yaml, cluster) {
+		t.Error("expecting", cluster)
+	}
+}

--- a/cmd/build/provider.go
+++ b/cmd/build/provider.go
@@ -66,5 +66,9 @@ func GetProvider(provider string) (Provider, error) {
 		return GithubActions{}, nil
 	}
 
+	if providerString == "awscodebuild" {
+		return AWSCodeBuild{}, nil
+	}
+
 	return nil, errors.New("build provider not supported: " + provider)
 }


### PR DESCRIPTION
```
fargate-create build awscodebuild
```

This command outputs a simple `buildspec.yml` file that performs a docker build and deploy to fargate.