### PR TITLE
docs: remove stray backticks breaking README rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ If you'd like to install the latest prerelease, use this command:
 ```
 curl -s fargate-create.get.turnerlabs.io | RELEASE=develop sh
 ```
-````
 
 ### Usage
 


### PR DESCRIPTION
@awlawl noticed the readme wasn't rendering correctly.